### PR TITLE
Accessibility Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 - Fixed saving cookie for mac users. ([#27](https://github.com/kartFr/Asset-Reuploader/pull/27))
+- Added accessibility changes:
+  - Added port to startup message.
+  - Added message to tell user you can rerun without restarting when finished reuploading.
+  - Fixed stats displaying on failure to start reuploading.
 
 # [1.3.1](https://github.com/kartFr/Asset-Reuploader/releases/tag/1.3.1) - April 27th, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Unreleased
 
 - Fixed saving cookie for mac users. ([#27](https://github.com/kartFr/Asset-Reuploader/pull/27))
-- Added accessibility changes:
-  - Added port to startup message.
-  - Added message to tell user you can rerun without restarting when finished reuploading.
-  - Fixed stats displaying on failure to start reuploading.
-  - Fixed notification header being tiny.
+
+### Accessibility changes (#23)
+
+- Added port to startup message.
+- Added message to tell user you can rerun without restarting when finished reuploading.
+- Changed default port from `61048` to `38073`
+- Changed valid port range from `2049-65535` to `1024-49151`
+- Fixed stats displaying on failure to start reuploading.
+- Fixed notification header being tiny.
 
 # [1.3.1](https://github.com/kartFr/Asset-Reuploader/releases/tag/1.3.1) - April 27th, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Added port to startup message.
   - Added message to tell user you can rerun without restarting when finished reuploading.
   - Fixed stats displaying on failure to start reuploading.
+  - Fixed notification header being tiny.
 
 # [1.3.1](https://github.com/kartFr/Asset-Reuploader/releases/tag/1.3.1) - April 27th, 2025
 

--- a/cmd/assetreuploader/assetreuploader.go
+++ b/cmd/assetreuploader/assetreuploader.go
@@ -13,7 +13,10 @@ import (
 	"github.com/kartFr/Asset-Reuploader/internal/roblox"
 )
 
-var cookieFile = config.Get("cookie_file")
+var (
+	cookieFile = config.Get("cookie_file")
+	port       = config.Get("port")
+)
 
 func main() {
 	console.ClearScreen()
@@ -42,7 +45,7 @@ func main() {
 		color.Error.Println("Failed to save cookie: ", err)
 	}
 
-	fmt.Println("localhost started. Waiting to start reuploading.")
+	fmt.Println("localhost started on port " + port + ". Waiting to start reuploading.")
 	if err := serve(c); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/assetreuploader/router.go
+++ b/cmd/assetreuploader/router.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/kartFr/Asset-Reuploader/internal/app/assets"
-	"github.com/kartFr/Asset-Reuploader/internal/app/config"
 	"github.com/kartFr/Asset-Reuploader/internal/app/request"
 	"github.com/kartFr/Asset-Reuploader/internal/app/response"
 	"github.com/kartFr/Asset-Reuploader/internal/color"
@@ -17,8 +16,6 @@ import (
 )
 
 var CompatiblePluginVersion = ""
-
-var port = config.Get("port")
 
 func getOutputFileName(reuploadType string) string {
 	t := time.Now()
@@ -59,7 +56,7 @@ func serve(c *roblox.Client) error {
 				respHistory = make([]response.ResponseItem, 0)
 
 				fmt.Fprint(w, "done")
-				fmt.Println("Finished reuploading")
+				fmt.Println("Finished reuploading. (you can rerun without restarting)")
 			}
 
 			return
@@ -116,13 +113,17 @@ func serve(c *roblox.Client) error {
 
 		go func() {
 			start := time.Now()
-			startReupload()
+			err := startReupload()
+			busy = false
+			if err != nil {
+				finished = true
+				color.Error.Println("Failed to start reuploading: ", err)
+				return
+			}
 
 			duration := time.Since(start)
 			fmt.Printf("Reuploading took %d hours, %d minutes, and %d seconds\n", int(duration.Hours()), int(duration.Minutes())%60, int(duration.Seconds())%60)
 			fmt.Println("Waiting for client to finish changing ids...")
-
-			busy = false
 		}()
 
 		w.WriteHeader(http.StatusOK)

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,2 @@
-port=51048
+port=38073
 cookie_file=cookie.txt

--- a/internal/app/assets/assets.go
+++ b/internal/app/assets/assets.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kartFr/Asset-Reuploader/internal/app/context"
 	"github.com/kartFr/Asset-Reuploader/internal/app/request"
 	"github.com/kartFr/Asset-Reuploader/internal/app/response"
-	"github.com/kartFr/Asset-Reuploader/internal/color"
 	"github.com/kartFr/Asset-Reuploader/internal/console"
 	"github.com/kartFr/Asset-Reuploader/internal/roblox"
 )
@@ -19,13 +18,13 @@ var assetModules = map[string]func(ctx *context.Context, r *request.Request){
 	"Animation": animation.Reupload,
 }
 
-func NewReuploadHandlerWithType(assetType string, c *roblox.Client, r *request.RawRequest, resp *response.Response) (func(), error) {
+func NewReuploadHandlerWithType(assetType string, c *roblox.Client, r *request.RawRequest, resp *response.Response) (func() error, error) {
 	reupload, exists := assetModules[assetType]
 	if !exists {
-		return func() {}, errors.New(assetType + " module does not exist")
+		return func() error { return nil }, errors.New(assetType + " module does not exist")
 	}
 
-	return func() {
+	return func() error {
 		ctx := context.New(c, resp)
 
 		console.ClearScreen()
@@ -34,8 +33,7 @@ func NewReuploadHandlerWithType(assetType string, c *roblox.Client, r *request.R
 		req, err := request.FromRawRequest(c, r)
 		console.ClearScreen()
 		if err != nil {
-			color.Error.Println(err)
-			return
+			return err
 		}
 
 		fmt.Println("Checking if account can edit universe...")
@@ -46,6 +44,7 @@ func NewReuploadHandlerWithType(assetType string, c *roblox.Client, r *request.R
 		}
 
 		reupload(ctx, req)
+		return nil
 	}, nil
 }
 

--- a/plugin/src/App/Tabs/Settings.luau
+++ b/plugin/src/App/Tabs/Settings.luau
@@ -28,8 +28,8 @@ return function(ui: UiLibrary.Ui, plugin: Plugin)
         local newPort = tonumber(input)
         if not newPort then return end
 
-        if newPort <= 2048 or newPort > 65535 then
-            ui:Notify("Notification", "Port has to be between 2049-65535.")
+        if newPort < 1024 or newPort > 49151 then
+            ui:Notify("Notification", "Port has to be between 1024-49151.")
             return
         end
 

--- a/plugin/src/UiLibrary/init.luau
+++ b/plugin/src/UiLibrary/init.luau
@@ -88,6 +88,7 @@ local function UpdateTheme(self: Ui)
 	Theme.updateText(notificationMainFrame.Close, true)
 	Theme.updateText(notificationMainFrame.Description, true)
 	Theme.updateText(notificationMainFrame.Title, true)
+	notificationMainFrame.Title.TextSize += 10
 	notificationMainFrame.Image = theme.NotificationImage
 	notificationMainFrame.BackgroundColor3 = theme.ForegroundColor
 	notificationMainFrame.Transparency = theme.NotificationTransparency

--- a/plugin/src/init.server.luau
+++ b/plugin/src/init.server.luau
@@ -23,7 +23,7 @@ widget:GetPropertyChangedSignal("Enabled"):Connect(function() toggleButton:SetAc
 widget.Title = `Asset Reuploader {currentVersion}`
 
 if plugin:GetSetting("Port") == nil then
-	plugin:SetSetting("Port", 51048)
+	plugin:SetSetting("Port", 38073)
 end
 
 local ui = UiLibrary.new(widget, plugin)


### PR DESCRIPTION
- Added port to startup message.
- Added message to tell user you can rerun without restarting when finished reuploading.
- Changed default port from `61048` to `38073`
- Changed valid port range from `2049-65535` to `1024-49151`
- Fixed stats displaying on failure to start reuploading.
- Fixed notification header being tiny.
- Added + button to text input so its more accessible.