### PR TITLE
Fix 410 Gone: migrate animation uploads to Open Cloud API

### DIFF
--- a/cmd/assetreuploader/assetreuploader.go
+++ b/cmd/assetreuploader/assetreuploader.go
@@ -20,31 +20,26 @@ var (
 
 func main() {
 	console.ClearScreen()
-
 	fmt.Println("Authenticating cookie...")
-
 	cookie, readErr := files.Read(cookieFile)
 	cookie = strings.TrimSpace(cookie)
-
 	c, clientErr := roblox.NewClient(cookie)
 	console.ClearScreen()
-
 	if readErr != nil || clientErr != nil {
 		if readErr != nil && !os.IsNotExist(readErr) {
 			color.Error.Println(readErr)
 		}
-
 		if clientErr != nil && cookie != "" {
 			color.Error.Println(clientErr)
 		}
-
 		getCookie(c)
 	}
-
 	if err := files.Write(cookieFile, c.Cookie); err != nil {
 		color.Error.Println("Failed to save cookie: ", err)
 	}
-
+	if strings.TrimSpace(config.Get("api_key")) == "" {
+		getAPIKey()
+	}
 	fmt.Println("localhost started on port " + port + ". Waiting to start reuploading.")
 	if err := serve(c); err != nil {
 		log.Fatal(err)
@@ -59,7 +54,6 @@ func getCookie(c *roblox.Client) {
 			color.Error.Println(err)
 			continue
 		}
-
 		fmt.Println("Authenticating cookie...")
 		err = c.SetCookie(i)
 		console.ClearScreen()
@@ -67,8 +61,31 @@ func getCookie(c *roblox.Client) {
 			color.Error.Println(err)
 			continue
 		}
-
 		files.Write(cookieFile, i)
+		break
+	}
+}
+
+func getAPIKey() {
+	for {
+		fmt.Println("An Open Cloud API Key is required for animation uploads.")
+		fmt.Println("Get one at: https://create.roblox.com/dashboard/credentials?activeTab=ApiKeysTab")
+		fmt.Println("(Create API Key -> Assets -> Write permission)")
+		i, err := console.LongInput("API Key: ")
+		console.ClearScreen()
+		if err != nil {
+			color.Error.Println(err)
+			continue
+		}
+		i = strings.TrimSpace(i)
+		if i == "" {
+			color.Error.Println("API Key cannot be empty")
+			continue
+		}
+		config.Set("api_key", i)
+		if err := config.Save(); err != nil {
+			color.Error.Println("Failed to save API Key: ", err)
+		}
 		break
 	}
 }

--- a/cmd/assetreuploader/ensure_api_key.go
+++ b/cmd/assetreuploader/ensure_api_key.go
@@ -1,0 +1,62 @@
+// assetreuploader.go — PATCH: add ensureAPIKey() call and function
+//
+// In main(), after saving the cookie (around line 44), add:
+//     ensureAPIKey()
+//
+// Then add the following function at the bottom of the file:
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gookit/color"
+	"github.com/kartFr/Asset-Reuploader/internal/app/config"
+	"github.com/kartFr/Asset-Reuploader/internal/console"
+)
+
+// ensureAPIKey prompts the user to enter an Open Cloud API key if none is
+// configured. The key is required for animation uploads since Roblox deprecated
+// the old UploadNewAnimation endpoint (HTTP 410 as of ~April 2026).
+func ensureAPIKey() {
+	if strings.TrimSpace(config.Get("api_key")) != "" {
+		return // already configured
+	}
+
+	fmt.Println()
+	fmt.Println("════════════════════════════════════════════════════════")
+	fmt.Println("  Open Cloud API Key Required for Animation Uploads")
+	fmt.Println("════════════════════════════════════════════════════════")
+	fmt.Println("Roblox deprecated the old animation upload endpoint.")
+	fmt.Println("You now need a free Open Cloud API key.")
+	fmt.Println()
+	fmt.Println("How to get one (takes ~1 minute):")
+	fmt.Println("  1. Go to https://create.roblox.com/dashboard/credentials?activeTab=ApiKeysTab")
+	fmt.Println("  2. Click  Create API Key")
+	fmt.Println("  3. Enter any name (e.g. \"Asset Reuploader\")")
+	fmt.Println("  4. Under  Select API System  choose  Assets")
+	fmt.Println("  5. Enable  Write  permission for Assets")
+	fmt.Println("  6. Click  Save  and copy the key")
+	fmt.Println()
+
+	key, err := console.Input("Paste your API key here (leave blank to skip): ")
+	if err != nil {
+		color.Error.Println(err)
+		return
+	}
+
+	key = strings.TrimSpace(key)
+	if key == "" {
+		fmt.Println("Skipping — animation reuploads will fail until api_key is set in config.ini")
+		return
+	}
+
+	config.Set("api_key", key)
+	if err := config.Save(); err != nil {
+		color.Error.Println("Failed to save api_key to config.ini:", err)
+		return
+	}
+	fmt.Println("API key saved to config.ini ✓")
+	fmt.Println()
+}

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,0 @@
-port=38073
-cookie_file=cookie.txt

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 )
 
 require (
+	github.com/gookit/color v1.6.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+github.com/gookit/color v1.6.1 h1:KoTnDxJPRgrL0SoX0f8rCFg2zI0t4E3GZZBMo2nN8LU=
+github.com/gookit/color v1.6.1/go.mod h1:9ACFc7/1IpHGBW8RwuDm/0YEnhg3dwwXpoMsmtyHfjs=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/internal/app/assets/animation/animation.go
+++ b/internal/app/assets/animation/animation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kartFr/Asset-Reuploader/internal/roblox/assetdelivery"
 	"github.com/kartFr/Asset-Reuploader/internal/roblox/develop"
 	"github.com/kartFr/Asset-Reuploader/internal/roblox/games"
+	"github.com/kartFr/Asset-Reuploader/internal/app/config"
 	"github.com/kartFr/Asset-Reuploader/internal/roblox/ide"
 	"github.com/kartFr/Asset-Reuploader/internal/shardedmap"
 	"github.com/kartFr/Asset-Reuploader/internal/taskqueue"
@@ -106,42 +107,47 @@ func Reupload(ctx *context.Context, r *request.Request) {
 			return
 		}
 
-		uploadHandler, err := ide.NewUploadAnimationHandler(client, assetInfo.Name, "", assetData, groupID)
-		if err != nil {
-			newUploadError("Failed to get upload handler", assetInfo, err)
-			return
-		}
-
 		res := <-uploadQueue.QueueTask(func() (int64, error) {
-			return retry.Do(
-				retry.NewOptions(retry.Tries(3)),
-				func(try int) (int64, error) {
-					pauseController.WaitIfPaused()
-					if try > 1 {
-						uploadQueue.Limiter.Wait()
-					}
+	return retry.Do(
+		retry.NewOptions(retry.Tries(3)),
+		func(try int) (int64, error) {
+			pauseController.WaitIfPaused()
+			if try > 1 {
+				uploadQueue.Limiter.Wait()
+			}
+			apiKey := config.Get("api_key")
+			creatorType := "User"
+			if groupID > 0 {
+				creatorType = "Group"
+			}
+			creatorID := int64(groupID)
+if creatorType == "User" {
+    creatorID = client.UserInfo.ID
+}
+id, err := ide.UploadAnimationOpenCloud(client.GetHTTPClient(), apiKey, assetInfo.Name, assetData.Bytes(), creatorType, creatorID)
+if err == nil {
+    return id, nil
+}
+switch err {
+case ide.UploadAnimationErrors.ErrInappropriateName:
+    assetInfo.Name = fmt.Sprintf("(%s) [Censored]", assetInfo.Name)
+case ide.ErrRateLimited:
+    wait := time.Minute * time.Duration(1<<(try-1))
+    if wait > 32*time.Minute {
+        wait = 32 * time.Minute
+    }
+    time.Sleep(wait)
+default:
+    switch err.(type) {
+    case *net.OpError, *net.DNSError:
+        uploadQueue.Limiter.Decrement()
+    }
+}
+return 0, &retry.ContinueRetry{Err: err}
+		},
+	)
+})
 
-					id, err := uploadHandler()
-					if err == nil {
-						return id, nil
-					}
-
-					switch err {
-					case ide.UploadAnimationErrors.ErrNotLoggedIn:
-						clientutils.GetNewCookie(ctx, r, "cookie expired")
-					case ide.UploadAnimationErrors.ErrInappropriateName:
-						assetInfo.Name = fmt.Sprintf("(%s) [Censored]", assetInfo.Name)
-					default:
-						switch err.(type) {
-						case *net.OpError, *net.DNSError:
-							uploadQueue.Limiter.Decrement()
-						}
-					}
-
-					return 0, &retry.ContinueRetry{Err: err}
-				},
-			)
-		})
 
 		if err := res.Error; err != nil {
 			assetInfo.Name = oldName

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -2,32 +2,45 @@ package config
 
 import (
 	"bufio"
+	"log"
+	"os"
+	"sort"
 	"strings"
 
 	"github.com/kartFr/Asset-Reuploader/internal/files"
 )
 
 var (
-	config        = make(map[string]string, 0)
+	config = map[string]string{}
+
 	defaultConfig = map[string]string{
 		"port":        "38073",
 		"cookie_file": "cookie.txt",
+		"api_key":     "",
 	}
 )
 
 func init() {
 	contents, err := files.Read("config.ini")
+	if err != nil && !os.IsNotExist(err) {
+		log.Printf("failed reading config.ini, using defaults: %v", err)
+	}
 	if err != nil {
-		scanner := bufio.NewScanner(strings.NewReader(contents))
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			split := strings.Split(line, "=")
-			if len(split) != 2 {
-				continue
-			}
+		contents = ""
+	}
 
-			config[split[0]] = split[1]
+	scanner := bufio.NewScanner(strings.NewReader(contents))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		split := strings.SplitN(line, "=", 2)
+		if len(split) != 2 {
+			continue
 		}
+		key := strings.TrimSpace(split[0])
+		if key == "" {
+			continue
+		}
+		config[key] = split[1]
 	}
 
 	for i, v := range defaultConfig {
@@ -40,4 +53,25 @@ func init() {
 
 func Get(key string) string {
 	return config[key]
+}
+
+func Set(key string, value string) {
+	config[key] = value
+}
+
+func Save() error {
+	var out strings.Builder
+	keys := make([]string, 0, len(config))
+	for key := range config {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		out.WriteString(key)
+		out.WriteByte('=')
+		out.WriteString(config[key])
+		out.WriteByte('\n')
+	}
+	return files.Write("config.ini", out.String())
 }

--- a/internal/roblox/client.go
+++ b/internal/roblox/client.go
@@ -70,3 +70,7 @@ func (c *Client) SetToken(s string) {
 func (c *Client) DoRequest(req *http.Request) (*http.Response, error) {
 	return c.httpClient.Do(req)
 }
+
+func (c *Client) GetHTTPClient() *http.Client {
+	return c.httpClient
+}

--- a/internal/roblox/ide/assets_upload.go
+++ b/internal/roblox/ide/assets_upload.go
@@ -1,0 +1,184 @@
+package ide
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+)
+
+// ErrRateLimited is returned when the Open Cloud API responds with 429.
+var ErrRateLimited = errors.New("rate limited by Roblox Open Cloud API")
+
+const openCloudAssetsURL = "https://apis.roblox.com/assets/v1/assets"
+
+// openCloudOperationResponse is the async operation response from the Assets API.
+type openCloudOperationResponse struct {
+	Path     string `json:"path"`
+	Done     bool   `json:"done"`
+	Response *struct {
+		AssetID int64 `json:"assetId,string"`
+	} `json:"response,omitempty"`
+	Error *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// UploadAnimationOpenCloud uploads an animation file via the Roblox Open Cloud
+// Assets API using the provided API key.
+// creatorType should be "User" or "Group", creatorID is the numeric ID.
+// animData is the raw .rbxanim / KeyframeSequence bytes.
+// Returns the new asset ID on success.
+func UploadAnimationOpenCloud(
+	client *http.Client,
+	apiKey string,
+	animName string,
+	animData []byte,
+	creatorType string,
+	creatorID int64,
+) (int64, error) {
+	// Build multipart body
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+
+	// Part 1: JSON request metadata
+	metaHeader := textproto.MIMEHeader{}
+	metaHeader.Set("Content-Type", "application/json")
+	metaHeader.Set("Content-Disposition", `form-data; name="request"`)
+	metaPart, err := mw.CreatePart(metaHeader)
+	if err != nil {
+		return 0, fmt.Errorf("creating metadata part: %w", err)
+	}
+
+	creatorField := "userId"
+	if strings.EqualFold(creatorType, "Group") {
+		creatorField = "groupId"
+	}
+
+	meta := map[string]interface{}{
+		"assetType":   "Animation",
+		"displayName": animName,
+		"description": "",
+		"creationContext": map[string]interface{}{
+			"creator": map[string]interface{}{
+				creatorField: creatorID,
+			},
+		},
+	}
+	if err := json.NewEncoder(metaPart).Encode(meta); err != nil {
+		return 0, fmt.Errorf("encoding metadata: %w", err)
+	}
+
+	// Part 2: binary animation data
+	fileHeader := textproto.MIMEHeader{}
+	fileHeader.Set("Content-Type", "model/x-rbxm")
+	fileHeader.Set("Content-Disposition", `form-data; name="fileContent"; filename="animation.rbxm"`)
+	filePart, err := mw.CreatePart(fileHeader)
+	if err != nil {
+		return 0, fmt.Errorf("creating file part: %w", err)
+	}
+	if _, err := io.Copy(filePart, bytes.NewReader(animData)); err != nil {
+		return 0, fmt.Errorf("writing animation data: %w", err)
+	}
+
+	if err := mw.Close(); err != nil {
+		return 0, fmt.Errorf("closing multipart writer: %w", err)
+	}
+
+	// Send upload request
+	req, err := http.NewRequest(http.MethodPost, openCloudAssetsURL, &body)
+	if err != nil {
+		return 0, fmt.Errorf("building upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("x-api-key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("upload request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return 0, ErrRateLimited
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return 0, fmt.Errorf("API key rejected (HTTP %d) — make sure it has Assets Write permission", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("unexpected HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	// Decode operation response
+	rawUpload, _ := io.ReadAll(resp.Body)
+	var op openCloudOperationResponse
+	if err := json.Unmarshal(rawUpload, &op); err != nil {
+		return 0, fmt.Errorf("decoding operation response: %w", err)
+	}
+
+	if op.Done {
+		return extractAssetID(op)
+	}
+
+	if op.Path == "" {
+		return 0, errors.New("empty operation path in response")
+	}
+	return pollOperation(client, apiKey, op.Path)
+}
+
+// pollOperation polls the async operation endpoint until Done == true.
+func pollOperation(client *http.Client, apiKey, opPath string) (int64, error) {
+	pollURL := "https://apis.roblox.com/assets/v1/" + opPath
+	const maxAttempts = 20
+	backoff := 500 * time.Millisecond
+
+	for i := 0; i < maxAttempts; i++ {
+		time.Sleep(backoff)
+		if backoff < 5*time.Second {
+			backoff *= 2
+		}
+
+		req, err := http.NewRequest(http.MethodGet, pollURL, http.NoBody)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("x-api-key", apiKey)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		rawBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var op openCloudOperationResponse
+		if err := json.Unmarshal(rawBody, &op); err != nil {
+			continue
+		}
+
+		if op.Done {
+			return extractAssetID(op)
+		}
+	}
+	return 0, errors.New("timed out waiting for upload operation to complete")
+}
+
+func extractAssetID(op openCloudOperationResponse) (int64, error) {
+	if op.Error != nil {
+		return 0, fmt.Errorf("upload rejected by Roblox: %s", op.Error.Message)
+	}
+	if op.Response == nil || op.Response.AssetID == 0 {
+		return 0, errors.New("operation succeeded but returned no asset ID")
+	}
+	return op.Response.AssetID, nil
+}


### PR DESCRIPTION
I've been at it for 6 hours now, but I managed to fix it temporarily (it will probably break again if Roblox updates its entire system). You can try it.
I tested it with up to 2000 animations and it worked fine.
<img width="650" height="424" alt="Captura de pantalla 2026-05-03 165343" src="https://github.com/user-attachments/assets/64bea3b8-6dab-4d8a-8842-e8a17da15ad6" />
